### PR TITLE
Remove images when marking point shrinks

### DIFF
--- a/app/controllers/marking-tool.coffee
+++ b/app/controllers/marking-tool.coffee
@@ -58,11 +58,14 @@ class MarkingTool extends MagnifierPointTool
       if @collapsed then @collapse() else @expand()
 
     super
+    unless @image.el.parentNode
+      @group.el.appendChild @image.el
     @disc.attr r: @radius
     @clipCircle.attr r: @radius
 
   deselect: ->
     super
+    @image.remove()
     @disc.attr r: 7, strokeDasharray: []
     @clipCircle.attr r: 7
 
@@ -75,7 +78,7 @@ class MarkingTool extends MagnifierPointTool
 
   collapse: ->
     @root.toggleClass 'collapsed', true
-    @image.attr 'opacity', 0
+    #@image.attr 'opacity', 0
     @disc.attr strokeDasharray: [@strokeWidth, @strokeWidth]
     @collapsed = true
     @trigger 'collapse'


### PR DESCRIPTION
Fixes #77

Basically as users on memory constrained computers added more points there would be more and more copies of the magnified image in memory causing the site to slow as users' computer ran low on memory.  

This just removes the magnified image when the marking point is deselected and adds it back when the point is reselected. It seems to solve the problem. 
